### PR TITLE
fix(py,js): Flatten thinking blocks in trajectory judge prompts

### DIFF
--- a/js/src/trajectory/llm.ts
+++ b/js/src/trajectory/llm.ts
@@ -2,7 +2,10 @@ import type { BaseMessage } from "@langchain/core/messages";
 import { _createLLMAsJudgeScorer } from "openevals/llm";
 
 import { _runEvaluator, _normalizeToOpenAIMessagesList } from "../utils.js";
-import { _chatCompletionMessagesToString } from "./utils.js";
+import {
+  _chatCompletionMessagesToString,
+  _flattenThinkingBlocks,
+} from "./utils.js";
 import {
   ChatCompletionMessage,
   FlexibleChatCompletionMessage,
@@ -81,7 +84,7 @@ Grade the following trajectory:
 {outputs}
 </trajectory>`;
 
-function _formatInputs(params: {
+export function _formatInputs(params: {
   outputs:
     | ChatCompletionMessage[]
     | FlexibleChatCompletionMessage[]
@@ -106,9 +109,11 @@ function _formatInputs(params: {
       };
 }): [string, string] {
   const { outputs, referenceOutputs } = params;
-  const normalizedOutputs = _normalizeToOpenAIMessagesList(outputs);
-  const normalizedReferenceOutputs = _normalizeToOpenAIMessagesList(
-    referenceOutputs ?? []
+  const normalizedOutputs = _flattenThinkingBlocks(
+    _normalizeToOpenAIMessagesList(outputs)
+  );
+  const normalizedReferenceOutputs = _flattenThinkingBlocks(
+    _normalizeToOpenAIMessagesList(referenceOutputs ?? [])
   );
 
   const formattedReferenceOutputs = normalizedReferenceOutputs

--- a/js/src/trajectory/tests/trajectory.test.ts
+++ b/js/src/trajectory/tests/trajectory.test.ts
@@ -5,6 +5,7 @@ import { expect } from "vitest";
 import { HumanMessage, AIMessage, ToolMessage } from "@langchain/core/messages";
 import { createTrajectoryMatchEvaluator } from "../match.js";
 import { FlexibleChatCompletionMessage } from "../../types.js";
+import { _flattenThinkingBlocks } from "../utils.js";
 
 ls.describe("trajectory", () => {
   ls.test.each([
@@ -1490,4 +1491,121 @@ ls.describe("trajectory", () => {
     });
     expect(evaluatorResult.score).toBe(score);
   });
+});
+
+ls.describe("flattenThinkingBlocks", () => {
+  ls.test(
+    "flattens Anthropic thinking blocks to tagged string",
+    { inputs: {} },
+    async () => {
+      const messages = [
+        {
+          role: "assistant",
+          content: [
+            { type: "thinking", thinking: "I should look this up" },
+            { type: "text", text: "Let me check that for you." },
+          ],
+        },
+      ];
+      const result = _flattenThinkingBlocks(messages as any);
+      expect(result[0].content).toBe(
+        "<thinking>I should look this up</thinking>\nLet me check that for you."
+      );
+    }
+  );
+
+  ls.test(
+    "flattens reasoning blocks to tagged string",
+    { inputs: {} },
+    async () => {
+      const messages = [
+        {
+          role: "assistant",
+          content: [
+            { type: "reasoning", reasoning: "Step 1: analyze" },
+            { type: "text", text: "Here is my answer." },
+          ],
+        },
+      ];
+      const result = _flattenThinkingBlocks(messages as any);
+      expect(result[0].content).toBe(
+        "<thinking>Step 1: analyze</thinking>\nHere is my answer."
+      );
+    }
+  );
+
+  ls.test("drops redacted thinking blocks", { inputs: {} }, async () => {
+    const messages = [
+      {
+        role: "assistant",
+        content: [
+          { type: "redacted_thinking", data: "opaque" },
+          { type: "text", text: "Final answer." },
+        ],
+      },
+    ];
+    const result = _flattenThinkingBlocks(messages as any);
+    expect(result[0].content).toBe("Final answer.");
+  });
+
+  ls.test(
+    "passes through string content unchanged",
+    { inputs: {} },
+    async () => {
+      const messages = [
+        { role: "assistant", content: "Just a normal message" },
+        { role: "user", content: "Hello" },
+      ];
+      const result = _flattenThinkingBlocks(messages as any);
+      expect(result[0].content).toBe("Just a normal message");
+      expect(result[1].content).toBe("Hello");
+    }
+  );
+
+  ls.test(
+    "handles only thinking blocks with no text",
+    { inputs: {} },
+    async () => {
+      const messages = [
+        {
+          role: "assistant",
+          content: [
+            { type: "thinking", thinking: "Just reasoning, no output" },
+          ],
+        },
+      ];
+      const result = _flattenThinkingBlocks(messages as any);
+      expect(result[0].content).toBe(
+        "<thinking>Just reasoning, no output</thinking>"
+      );
+    }
+  );
+
+  ls.test(
+    "preserves tool_calls alongside flattened content",
+    { inputs: {} },
+    async () => {
+      const messages = [
+        {
+          role: "assistant",
+          content: [
+            { type: "thinking", thinking: "I need the weather tool" },
+            { type: "text", text: "Let me check." },
+          ],
+          tool_calls: [
+            {
+              function: {
+                name: "get_weather",
+                arguments: JSON.stringify({ city: "SF" }),
+              },
+            },
+          ],
+        },
+      ];
+      const result = _flattenThinkingBlocks(messages as any);
+      expect(typeof result[0].content).toBe("string");
+      expect(result[0].tool_calls).toBeDefined();
+      expect(result[0].tool_calls!.length).toBe(1);
+    }
+  );
 });

--- a/js/src/trajectory/tests/trajectory_llm.test.ts
+++ b/js/src/trajectory/tests/trajectory_llm.test.ts
@@ -1,7 +1,9 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
 import * as ls from "langsmith/vitest";
 import { expect } from "vitest";
 
 import {
+  _formatInputs,
   createTrajectoryLLMAsJudge,
   TRAJECTORY_ACCURACY_PROMPT,
 } from "../llm.js";
@@ -225,6 +227,31 @@ According to this reference trajectory:
 
       expect(evalResult.key).toBe("trajectory_accuracy");
       expect(evalResult.score).toBe(false);
+    }
+  );
+
+  ls.test(
+    "_formatInputs flattens thinking blocks in the judge prompt",
+    { inputs: {} },
+    async () => {
+      const outputs = [
+        {
+          role: "assistant",
+          content: [
+            { type: "thinking", thinking: "private reasoning" },
+            { type: "text", text: "public answer" },
+          ],
+        },
+      ];
+      const [formattedOutputs, formattedReferenceOutputs] = _formatInputs({
+        outputs: outputs as any,
+        referenceOutputs: outputs as any,
+      });
+      for (const rendered of [formattedOutputs, formattedReferenceOutputs]) {
+        expect(rendered).toContain("<thinking>private reasoning</thinking>");
+        expect(rendered).toContain("public answer");
+        expect(rendered).not.toContain('"type": "thinking"');
+      }
     }
   );
 });

--- a/js/src/trajectory/utils.ts
+++ b/js/src/trajectory/utils.ts
@@ -219,6 +219,37 @@ export function _getMatcherForToolName(
   return matcher;
 }
 
+export function _flattenThinkingBlocks(
+  messages: ChatCompletionMessage[]
+): ChatCompletionMessage[] {
+  return messages.map((message) => {
+    const content = message.content;
+    if (!Array.isArray(content)) {
+      return message;
+    }
+    const parts: string[] = [];
+    for (const block of content) {
+      if (typeof block === "object" && block !== null) {
+        const blockType = (block as Record<string, unknown>).type;
+        if (blockType === "thinking" || blockType === "reasoning") {
+          const text =
+            (block as Record<string, unknown>)[blockType] ?? "";
+          parts.push(`<thinking>${text}</thinking>`);
+        } else if (blockType === "redacted_thinking") {
+          continue;
+        } else if (blockType === "text") {
+          parts.push(
+            ((block as Record<string, unknown>).text as string) ?? ""
+          );
+        }
+      } else if (typeof block === "string") {
+        parts.push(block);
+      }
+    }
+    return { ...message, content: parts.join("\n") };
+  });
+}
+
 export function _chatCompletionMessagesToString(
   messages: ChatCompletionMessage[]
 ): string {

--- a/python/agentevals/trajectory/llm.py
+++ b/python/agentevals/trajectory/llm.py
@@ -16,7 +16,10 @@ from openevals.utils import (
 )
 from agentevals.types import FewShotExample
 from agentevals.utils import _run_evaluator, _arun_evaluator
-from agentevals.trajectory.utils import _normalize_to_openai_messages_list
+from agentevals.trajectory.utils import (
+    _flatten_thinking_blocks,
+    _normalize_to_openai_messages_list,
+)
 
 from langchain_core.language_models.chat_models import BaseChatModel
 from langchain_core.runnables import Runnable
@@ -81,7 +84,9 @@ def _format_inputs(
     ],
 ) -> tuple[str, str]:
     outputs = _normalize_to_openai_messages_list(outputs)
+    outputs = _flatten_thinking_blocks(outputs)
     reference_outputs = _normalize_to_openai_messages_list(reference_outputs)
+    reference_outputs = _flatten_thinking_blocks(reference_outputs)
     if reference_outputs:
         formatted_reference_outputs = _chat_completion_messages_to_string(
             reference_outputs

--- a/python/agentevals/trajectory/utils.py
+++ b/python/agentevals/trajectory/utils.py
@@ -4,6 +4,7 @@ __all__ = [
     "_get_matcher_for_tool_name",
     "_normalize_to_openai_messages_list",
     "_convert_to_openai_message",
+    "_flatten_thinking_blocks",
 ]
 
 import json
@@ -42,6 +43,31 @@ def _convert_to_openai_message(
         if message.get("id") is not None and converted.get("id") is None:
             converted["id"] = message.get("id")
     return converted  # type: ignore
+
+
+def _flatten_thinking_blocks(
+    messages: list[ChatCompletionMessage],
+) -> list[ChatCompletionMessage]:
+    result = []
+    for message in messages:
+        content = message.get("content", "")
+        if isinstance(content, list):
+            parts = []
+            for block in content:
+                if isinstance(block, dict):
+                    block_type = block.get("type")
+                    if block_type in ("thinking", "reasoning"):
+                        text = block.get(block_type) or ""
+                        parts.append(f"<thinking>{text}</thinking>")
+                    elif block_type == "redacted_thinking":
+                        continue
+                    elif block_type == "text":
+                        parts.append(block.get("text", ""))
+                elif isinstance(block, str):
+                    parts.append(block)
+            message = {**message, "content": "\n".join(parts)}
+        result.append(message)
+    return result
 
 
 def _normalize_to_openai_messages_list(

--- a/python/tests/test_trajectory.py
+++ b/python/tests/test_trajectory.py
@@ -1,4 +1,8 @@
 from agentevals.trajectory.match import create_trajectory_match_evaluator
+from agentevals.trajectory.utils import (
+    _flatten_thinking_blocks,
+    _normalize_to_openai_messages_list,
+)
 
 from agentevals.types import EvaluatorResult, ChatCompletionMessage
 
@@ -1248,3 +1252,121 @@ def test_tool_args_match_mode_exact(tool_args_match_mode, score):
     )
     evaluator_result = evaluator(outputs=outputs, reference_outputs=reference_outputs)
     assert evaluator_result["score"] == score
+
+
+@pytest.mark.langsmith
+def test_flatten_thinking_blocks_anthropic():
+    messages = [
+        ChatCompletionMessage(
+            role="assistant",
+            content=[
+                {"type": "thinking", "thinking": "I should look this up"},
+                {"type": "text", "text": "Let me check that for you."},
+            ],
+        ),
+    ]
+    result = _flatten_thinking_blocks(messages)
+    assert result[0]["content"] == (
+        "<thinking>I should look this up</thinking>\nLet me check that for you."
+    )
+    assert result[0]["role"] == "assistant"
+
+
+@pytest.mark.langsmith
+def test_flatten_thinking_blocks_reasoning():
+    messages = [
+        ChatCompletionMessage(
+            role="assistant",
+            content=[
+                {"type": "reasoning", "reasoning": "Step 1: analyze the request"},
+                {"type": "text", "text": "Here is my answer."},
+            ],
+        ),
+    ]
+    result = _flatten_thinking_blocks(messages)
+    assert result[0]["content"] == (
+        "<thinking>Step 1: analyze the request</thinking>\nHere is my answer."
+    )
+
+
+@pytest.mark.langsmith
+def test_flatten_thinking_blocks_redacted():
+    messages = [
+        ChatCompletionMessage(
+            role="assistant",
+            content=[
+                {"type": "redacted_thinking", "data": "opaque"},
+                {"type": "text", "text": "Final answer."},
+            ],
+        ),
+    ]
+    result = _flatten_thinking_blocks(messages)
+    assert result[0]["content"] == "Final answer."
+
+
+@pytest.mark.langsmith
+def test_flatten_thinking_blocks_string_passthrough():
+    messages = [
+        ChatCompletionMessage(role="assistant", content="Just a normal message"),
+        ChatCompletionMessage(role="user", content="Hello"),
+    ]
+    result = _flatten_thinking_blocks(messages)
+    assert result[0]["content"] == "Just a normal message"
+    assert result[1]["content"] == "Hello"
+
+
+@pytest.mark.langsmith
+def test_flatten_thinking_blocks_only_thinking():
+    messages = [
+        ChatCompletionMessage(
+            role="assistant",
+            content=[
+                {"type": "thinking", "thinking": "Just reasoning, no output"},
+            ],
+        ),
+    ]
+    result = _flatten_thinking_blocks(messages)
+    assert result[0]["content"] == ("<thinking>Just reasoning, no output</thinking>")
+
+
+@pytest.mark.langsmith
+def test_flatten_thinking_blocks_with_langchain_messages():
+    messages = [
+        HumanMessage(content="What is the weather?"),
+        AIMessage(
+            content=[
+                {"type": "thinking", "thinking": "Let me think about this"},
+                {"type": "text", "text": "Checking now."},
+            ],
+        ),
+    ]
+    normalized = _normalize_to_openai_messages_list(messages)
+    result = _flatten_thinking_blocks(normalized)
+    assert isinstance(result[1]["content"], str)
+    assert "<thinking>" in result[1]["content"]
+    assert "Checking now." in result[1]["content"]
+
+
+@pytest.mark.langsmith
+def test_flatten_thinking_blocks_preserves_tool_calls():
+    messages = [
+        ChatCompletionMessage(
+            role="assistant",
+            content=[
+                {"type": "thinking", "thinking": "I need the weather tool"},
+                {"type": "text", "text": "Let me check."},
+            ],
+            tool_calls=[
+                {
+                    "function": {
+                        "name": "get_weather",
+                        "arguments": json.dumps({"city": "SF"}),
+                    }
+                }
+            ],
+        ),
+    ]
+    result = _flatten_thinking_blocks(messages)
+    assert isinstance(result[0]["content"], str)
+    assert result[0]["tool_calls"] is not None
+    assert len(result[0]["tool_calls"]) == 1

--- a/python/tests/test_trajectory_llm.py
+++ b/python/tests/test_trajectory_llm.py
@@ -1,4 +1,5 @@
 from agentevals.trajectory.llm import (
+    _format_inputs,
     create_trajectory_llm_as_judge,
     TRAJECTORY_ACCURACY_PROMPT_WITH_REFERENCE,
     TRAJECTORY_ACCURACY_PROMPT,
@@ -190,3 +191,23 @@ According to this reference trajectory:
     )
     assert eval_result["key"] == "trajectory_accuracy"
     assert not eval_result["score"]
+
+
+@pytest.mark.langsmith
+def test_format_inputs_flattens_thinking():
+    outputs = [
+        ChatCompletionMessage(
+            role="assistant",
+            content=[
+                {"type": "thinking", "thinking": "private reasoning"},
+                {"type": "text", "text": "public answer"},
+            ],
+        ),
+    ]
+    formatted_outputs, formatted_reference_outputs = _format_inputs(
+        outputs, reference_outputs=outputs
+    )
+    for rendered in (formatted_outputs, formatted_reference_outputs):
+        assert "<thinking>private reasoning</thinking>" in rendered
+        assert "public answer" in rendered
+        assert "'type': 'thinking'" not in rendered


### PR DESCRIPTION
Fixes #62

`thinking`/`reasoning` content blocks were passed through to the judge prompt as structured blocks, so the judge saw stringified dicts instead of prose. Flattens them to `<thinking>...</thinking>` before `_chat_completion_messages_to_string`, matching the existing `<tool_call>` tag convention. Drops `redacted_thinking`.