### PR TITLE
fix: patch 4 security alerts (medium severity)

### DIFF
--- a/js/package.json
+++ b/js/package.json
@@ -49,7 +49,8 @@
   "resolutions": {
     "form-data": "^4.0.4",
     "tar": "^7.5.11",
-    "axios": "^1.8.2",
+    "axios": "^1.15.0",
+    "langsmith": "^0.5.19",
     "lodash": "^4.18.1",
     "js-yaml": "^4.1.1",
     "vite": "^6.4.2",

--- a/js/yarn.lock
+++ b/js/yarn.lock
@@ -878,13 +878,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/uuid@npm:^10.0.0":
-  version: 10.0.0
-  resolution: "@types/uuid@npm:10.0.0"
-  checksum: e3958f8b0fe551c86c14431f5940c3470127293280830684154b91dc7eb3514aeb79fe3216968833cf79d4d1c67f580f054b5be2cd562bebf4f728913e73e944
-  languageName: node
-  linkType: hard
-
 "@typescript-eslint/eslint-plugin@npm:^8.24.1":
   version: 8.24.1
   resolution: "@typescript-eslint/eslint-plugin@npm:8.24.1"
@@ -1384,14 +1377,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"axios@npm:^1.8.2":
-  version: 1.13.5
-  resolution: "axios@npm:1.13.5"
+"axios@npm:^1.15.0":
+  version: 1.15.1
+  resolution: "axios@npm:1.15.1"
   dependencies:
     follow-redirects: ^1.15.11
     form-data: ^4.0.5
-    proxy-from-env: ^1.1.0
-  checksum: 985024c4a32f837053f198f02a308fd6f8bfb4053a2f21e39e37992bc6d06917f008679c36b3e7f0f0c9060c85ffe37c61e58d2ac662595d68dc1b89cef78de8
+    proxy-from-env: ^2.1.0
+  checksum: 5195540056a14b54cb85aa0d22aa672afda6317dd36d4d04f4e257da935c9f27404fb5abc6dd07c9c5fd6489b9763b5623e2b2da926999015e82321119da71eb
   languageName: node
   linkType: hard
 
@@ -1551,13 +1544,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"chalk@npm:^5.6.2":
-  version: 5.6.2
-  resolution: "chalk@npm:5.6.2"
-  checksum: 4ee2d47a626d79ca27cb5299ecdcce840ef5755e287412536522344db0fc51ca0f6d6433202332c29e2288c6a90a2b31f3bd626bc8c14743b6b6ee28abd3b796
-  languageName: node
-  linkType: hard
-
 "check-error@npm:^2.1.1":
   version: 2.1.1
   resolution: "check-error@npm:2.1.1"
@@ -1649,15 +1635,6 @@ __metadata:
   version: 1.0.11
   resolution: "confusing-browser-globals@npm:1.0.11"
   checksum: 3afc635abd37e566477f610e7978b15753f0e84025c25d49236f1f14d480117185516bdd40d2a2167e6bed8048641a9854964b9c067e3dcdfa6b5d0ad3c3a5ef
-  languageName: node
-  linkType: hard
-
-"console-table-printer@npm:^2.12.1":
-  version: 2.12.1
-  resolution: "console-table-printer@npm:2.12.1"
-  dependencies:
-    simple-wcswidth: "npm:^1.0.1"
-  checksum: 4d58fd4f18d3a69f421c9b0ffd44e5b0542677423491199e92c3e5ca0c023a06304a94bcc60f0d2b480a06cdf0720d2f228807f2af127abc8c905e73fcf64363
   languageName: node
   linkType: hard
 
@@ -3302,37 +3279,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"langsmith@npm:>=0.3.26, langsmith@npm:>=0.5.0 <1.0.0":
-  version: 0.5.7
-  resolution: "langsmith@npm:0.5.7"
-  dependencies:
-    "@types/uuid": ^10.0.0
-    chalk: ^5.6.2
-    console-table-printer: ^2.12.1
-    p-queue: ^6.6.2
-    semver: ^7.6.3
-    uuid: ^10.0.0
-  peerDependencies:
-    "@opentelemetry/api": "*"
-    "@opentelemetry/exporter-trace-otlp-proto": "*"
-    "@opentelemetry/sdk-trace-base": "*"
-    openai: "*"
-  peerDependenciesMeta:
-    "@opentelemetry/api":
-      optional: true
-    "@opentelemetry/exporter-trace-otlp-proto":
-      optional: true
-    "@opentelemetry/sdk-trace-base":
-      optional: true
-    openai:
-      optional: true
-  checksum: 6a130e6bda0e2e94a7e5462a347f168787e56c4fca02defc51bb6d6601a0408c8bae835e0a5bb5d358d184755512ba8d2ca8c023c2ae4e3e60da7d84fca5d37a
-  languageName: node
-  linkType: hard
-
-"langsmith@npm:>=0.5.19":
-  version: 0.5.19
-  resolution: "langsmith@npm:0.5.19"
+"langsmith@npm:^0.5.19":
+  version: 0.5.21
+  resolution: "langsmith@npm:0.5.21"
   dependencies:
     p-queue: 6.6.2
     uuid: 10.0.0
@@ -3353,7 +3302,7 @@ __metadata:
       optional: true
     ws:
       optional: true
-  checksum: 91ef8407a4b9da6b2bece97255ce5584b58e7f8ca7e914587f62449ae714ea07f30c1ad629a1e65d99da21d55f538b532719bd7af3d34ce421445e24b3199788
+  checksum: 89f919c2b54f76491c763b398f963da47ee106477ff2644783f3546a8ba75cbad9d9c4a8171fc3e95b76f0f94278b88c4f5734bc0144b03315130e33b1f1948a
   languageName: node
   linkType: hard
 
@@ -4057,10 +4006,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"proxy-from-env@npm:^1.1.0":
-  version: 1.1.0
-  resolution: "proxy-from-env@npm:1.1.0"
-  checksum: ed7fcc2ba0a33404958e34d95d18638249a68c430e30fcb6c478497d72739ba64ce9810a24f53a7d921d0c065e5b78e3822759800698167256b04659366ca4d4
+"proxy-from-env@npm:^2.1.0":
+  version: 2.1.0
+  resolution: "proxy-from-env@npm:2.1.0"
+  checksum: b106ad790f26d47ba4791af3fe8cba5c8d35d85020119c82c05b413eb11b3ab97d2393ecaed51bca97c2788fa256408283dfeb4d970b2ebcae6702310f064e7e
   languageName: node
   linkType: hard
 
@@ -4368,7 +4317,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"semver@npm:^7.3.5, semver@npm:^7.3.7, semver@npm:^7.6.0, semver@npm:^7.6.3":
+"semver@npm:^7.3.5, semver@npm:^7.3.7, semver@npm:^7.6.0":
   version: 7.7.1
   resolution: "semver@npm:7.7.1"
   bin:
@@ -4496,13 +4445,6 @@ __metadata:
   version: 4.1.0
   resolution: "signal-exit@npm:4.1.0"
   checksum: 64c757b498cb8629ffa5f75485340594d2f8189e9b08700e69199069c8e3070fb3e255f7ab873c05dc0b3cec412aea7402e10a5990cb6a050bd33ba062a6c549
-  languageName: node
-  linkType: hard
-
-"simple-wcswidth@npm:^1.0.1":
-  version: 1.0.1
-  resolution: "simple-wcswidth@npm:1.0.1"
-  checksum: dc5bf4cb131d9c386825d1355add2b1ecc408b37dc2c2334edd7a1a4c9f527e6b594dedcdbf6d949bce2740c3a332e39af1183072a2d068e40d9e9146067a37f
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Security Alert Patch

Resolves 4 Dependabot security alerts in the medium severity tier (no critical/high open).

### Packages Updated

| Package | Old Resolved | New Resolved | Strategy | Scope | CVEs Resolved |
|---------|--------------|--------------|----------|-------|---------------|
| axios | 1.13.5 | 1.15.1 | C (resolutions bump `^1.8.2` → `^1.15.0`) | dev-only (via `@langchain/scripts` devDep) | GHSA-3p68-rc4w-qgx5 (CVE-2025-62718), GHSA-fvcv-3m26-pcqx (CVE-2026-40175) |
| langsmith | 0.5.7 (transitive) | 0.5.21 (unified) | C (added resolution `^0.5.19`) | transitive — direct constraint already required `>=0.5.19` | GHSA-rr7j-v2q5-chgv, GHSA-fw9q-39r9-c252 (CVE-2026-40190) |

Strategy legend: A = direct bump, A-lockfile = direct dep lockfile-only, B = parent bump, C = override/resolution.
Scope legend: published = ships to end users, dev-only = local dev/CI only.

### Notes

- **axios** is transitive via `@langchain/scripts` (a devDependency). End users installing `agentevals` do not pull axios through this package — the fix is dev/CI-scoped.
- **langsmith** direct runtime constraint in `package.json` was already `>=0.5.19`. The vulnerable copy (0.5.7) was a transitive install via libraries with looser ranges (`>=0.3.26` / `>=0.5.0 <1.0.0`). Consumers of `agentevals` resolve langsmith against agentevals' own direct `>=0.5.19` constraint and pick a safe version — this PR simply unifies the in-repo lockfile to the safe version so local dev, CI, and tests use a patched install.
- Both bumps are minor/patch within the same major (axios 1.13 → 1.15; langsmith 0.5.7 → 0.5.21). No breaking-change assessment required.

### CVE Details

- **[GHSA-3p68-rc4w-qgx5](https://github.com/advisories/GHSA-3p68-rc4w-qgx5) / CVE-2025-62718** — Axios NO_PROXY hostname normalization bypass leading to SSRF. Fixed in 1.15.0.
- **[GHSA-fvcv-3m26-pcqx](https://github.com/advisories/GHSA-fvcv-3m26-pcqx) / CVE-2026-40175** — Axios unrestricted cloud metadata exfiltration via header injection chain. Fixed in 1.15.0.
- **[GHSA-rr7j-v2q5-chgv](https://github.com/advisories/GHSA-rr7j-v2q5-chgv)** — LangSmith SDK streaming token events bypass output redaction. Fixed in 0.5.19.
- **[GHSA-fw9q-39r9-c252](https://github.com/advisories/GHSA-fw9q-39r9-c252) / CVE-2026-40190** — LangSmith SDK prototype pollution via incomplete `__proto__` guard in internal lodash `set()`. Fixed in 0.5.18.

### Linear Tickets

No matching Linear tickets found.

### Verification

- [x] yarn.lock regenerated (package.json resolutions updated)
- [x] `yarn install` succeeds cleanly
- [x] `yarn format:check` passes
- [x] `yarn build` succeeds (tree shaking passes)
- [ ] `yarn lint` — pre-existing `eslint-plugin-import` / `minimatch` resolution error on `main`, unrelated to this change
- [ ] `yarn test` — 6/62 integration tests require `OPENAI_API_KEY`; CI's `build.yml` does not run the test suite on PR

Submitted by langster-patch.