### PR TITLE
fix: thread system param through trajectory llm judges

### DIFF
--- a/python/agentevals/graph_trajectory/llm.py
+++ b/python/agentevals/graph_trajectory/llm.py
@@ -88,6 +88,7 @@ def create_graph_trajectory_llm_as_judge(
     | Runnable
     | Callable[..., list[ChatCompletionMessage]] = DEFAULT_REF_COMPARE_PROMPT,
     model: Optional[str] = None,
+    system: Optional[str] = None,
     feedback_key: str = "graph_trajectory_accuracy",
     judge: Optional[
         Union[
@@ -128,6 +129,7 @@ def create_graph_trajectory_llm_as_judge(
         prompt=prompt,
         judge=judge,
         model=model,
+        system=system,
         continuous=continuous,
         choices=choices,
         use_reasoning=use_reasoning,
@@ -165,6 +167,7 @@ def create_async_graph_trajectory_llm_as_judge(
     | Runnable
     | Callable[..., list[ChatCompletionMessage]] = DEFAULT_REF_COMPARE_PROMPT,
     model: Optional[str] = None,
+    system: Optional[str] = None,
     feedback_key: str = "graph_trajectory_accuracy",
     judge: Optional[
         Union[
@@ -205,6 +208,7 @@ def create_async_graph_trajectory_llm_as_judge(
         prompt=prompt,
         judge=judge,
         model=model,
+        system=system,
         continuous=continuous,
         choices=choices,
         use_reasoning=use_reasoning,

--- a/python/agentevals/trajectory/llm.py
+++ b/python/agentevals/trajectory/llm.py
@@ -103,6 +103,7 @@ def create_trajectory_llm_as_judge(
         ..., list[ChatCompletionMessage]
     ] = TRAJECTORY_ACCURACY_PROMPT_WITH_REFERENCE,
     model: Optional[str] = None,
+    system: Optional[str] = None,
     feedback_key: str = "trajectory_accuracy",
     judge: Optional[
         Union[
@@ -143,6 +144,7 @@ def create_trajectory_llm_as_judge(
         prompt=prompt,
         judge=judge,
         model=model,
+        system=system,
         continuous=continuous,
         choices=choices,
         use_reasoning=use_reasoning,
@@ -181,6 +183,7 @@ def create_async_trajectory_llm_as_judge(
         ..., list[ChatCompletionMessage]
     ] = TRAJECTORY_ACCURACY_PROMPT_WITH_REFERENCE,
     model: Optional[str] = None,
+    system: Optional[str] = None,
     feedback_key: str = "trajectory_accuracy",
     judge: Optional[
         Union[
@@ -221,6 +224,7 @@ def create_async_trajectory_llm_as_judge(
         prompt=prompt,
         judge=judge,
         model=model,
+        system=system,
         continuous=continuous,
         choices=choices,
         use_reasoning=use_reasoning,

--- a/python/tests/graph_trajectory/test_graph_trajectory_llm.py
+++ b/python/tests/graph_trajectory/test_graph_trajectory_llm.py
@@ -11,6 +11,26 @@ from langchain_core.tools import tool
 import pytest
 
 
+def test_system_passed_to_scorer(monkeypatch):
+    captured = {}
+
+    def fake_create_llm_as_judge_scorer(**kwargs):
+        captured.update(kwargs)
+        return lambda **kwargs: {"score": True}
+
+    monkeypatch.setattr(
+        "agentevals.graph_trajectory.llm._create_llm_as_judge_scorer",
+        fake_create_llm_as_judge_scorer,
+    )
+
+    create_graph_trajectory_llm_as_judge(
+        model="openai:o3-mini",
+        system="Use the graph trajectory rubric.",
+    )
+
+    assert captured["system"] == "Use the graph trajectory rubric."
+
+
 @tool
 def search(query: str):
     """Call to surf the web."""

--- a/python/tests/graph_trajectory/test_graph_trajectory_llm_async.py
+++ b/python/tests/graph_trajectory/test_graph_trajectory_llm_async.py
@@ -11,6 +11,26 @@ from langchain_core.tools import tool
 import pytest
 
 
+def test_system_passed_to_scorer(monkeypatch):
+    captured = {}
+
+    def fake_create_async_llm_as_judge_scorer(**kwargs):
+        captured.update(kwargs)
+        return lambda **kwargs: {"score": True}
+
+    monkeypatch.setattr(
+        "agentevals.graph_trajectory.llm._create_async_llm_as_judge_scorer",
+        fake_create_async_llm_as_judge_scorer,
+    )
+
+    create_async_graph_trajectory_llm_as_judge(
+        model="openai:o3-mini",
+        system="Use the graph trajectory rubric.",
+    )
+
+    assert captured["system"] == "Use the graph trajectory rubric."
+
+
 @tool
 def search(query: str):
     """Call to surf the web."""

--- a/python/tests/test_trajectory_llm.py
+++ b/python/tests/test_trajectory_llm.py
@@ -10,6 +10,26 @@ import pytest
 import json
 
 
+def test_system_passed_to_scorer(monkeypatch):
+    captured = {}
+
+    def fake_create_llm_as_judge_scorer(**kwargs):
+        captured.update(kwargs)
+        return lambda **kwargs: {"score": True}
+
+    monkeypatch.setattr(
+        "agentevals.trajectory.llm._create_llm_as_judge_scorer",
+        fake_create_llm_as_judge_scorer,
+    )
+
+    create_trajectory_llm_as_judge(
+        model="openai:o3-mini",
+        system="Use the trajectory rubric.",
+    )
+
+    assert captured["system"] == "Use the trajectory rubric."
+
+
 @pytest.mark.langsmith
 def test_trajectory_match():
     evaluator = create_trajectory_llm_as_judge(

--- a/python/tests/test_trajectory_llm_async.py
+++ b/python/tests/test_trajectory_llm_async.py
@@ -10,6 +10,26 @@ import pytest
 import json
 
 
+def test_system_passed_to_scorer(monkeypatch):
+    captured = {}
+
+    def fake_create_async_llm_as_judge_scorer(**kwargs):
+        captured.update(kwargs)
+        return lambda **kwargs: {"score": True}
+
+    monkeypatch.setattr(
+        "agentevals.trajectory.llm._create_async_llm_as_judge_scorer",
+        fake_create_async_llm_as_judge_scorer,
+    )
+
+    create_async_trajectory_llm_as_judge(
+        model="openai:o3-mini",
+        system="Use the trajectory rubric.",
+    )
+
+    assert captured["system"] == "Use the trajectory rubric."
+
+
 @pytest.mark.langsmith
 @pytest.mark.asyncio
 async def test_trajectory_match():


### PR DESCRIPTION
## Summary
`create_trajectory_llm_as_judge` (and the async and graph variants) documented a `system` argument in their docstrings, and the README promises parity with openevals' `create_llm_as_judge`, but `system` was missing from every Python signature — so passing it raised `TypeError`.

## Why this matters
The JS evaluator already accepts `system` and forwards it to the same openevals scorer factory, so the underlying scorer supports it. This threads `system: Optional[str] = None` through the four Python factories and forwards it to the scorer call. Fully backward compatible.

## Testing
Added tests in all four trajectory judge test modules (sync/async, trajectory/graph) asserting the `system` parameter is accepted and forwarded.

Fixes #64

AI was used for assistance.
